### PR TITLE
Added platform check for arm recipe test

### DIFF
--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -16,12 +16,12 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            if "arm" in self.settings.arch:
-                    self.test_arm()
-            else:
-                bin_path = os.path.join("bin", "test_package")
-                self.run(bin_path, run_environment=True)
+        if "arm" in self.settings.arch:
+            if not tools.cross_building(self.settings):
+                self.test_arm()
+        else:
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)
 
     def test_arm(self):
         file_ext = "so" if self.options["libpng"].shared else "a"

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -18,7 +18,7 @@ class TestPackageConan(ConanFile):
     def test(self):
         arm_archs = ['arm', 'aarch64_be', 'aarch64', 'armv8b', 'armv8l']
         if "arm" in self.settings.arch:
-            if platform.machine() in arm_archs):
+            if platform.machine() in arm_archs:
                 self.test_arm()
         else:
             bin_path = os.path.join("bin", "test_package")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -16,13 +16,12 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        arm_archs = ['arm', 'aarch64_be', 'aarch64', 'armv8b', 'armv8l']
-        if "arm" in self.settings.arch:
-            if platform.machine() in arm_archs:
-                self.test_arm()
-        else:
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings):
+            if "arm" in self.settings.arch:
+                    self.test_arm()
+            else:
+                bin_path = os.path.join("bin", "test_package")
+                self.run(bin_path, run_environment=True)
 
     def test_arm(self):
         file_ext = "so" if self.options["libpng"].shared else "a"

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+import platform
 
 from conans import ConanFile, CMake, tools, RunEnvironment
 
@@ -15,8 +16,10 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
+        arm_archs = ['arm', 'aarch64_be', 'aarch64', 'armv8b', 'armv8l']
         if "arm" in self.settings.arch:
-            self.test_arm()
+            if platform.machine() in arm_archs):
+                self.test_arm()
         else:
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Attempting to run arm tests on a non-arm platform will fail, so check if the build machine actually uses arm before running the test.