### PR TITLE
name license according to spdx.org table

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class LibpngConan(ConanFile):
     url = "http://github.com/bincrafters/conan-libpng"
     author = "Bincrafters <bincrafters@gmail.com>"
     homepage = "http://www.libpng.org"
-    license = "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+    license = "libpng-2.0"
     exports = ["LICENSE.md"]
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"


### PR DESCRIPTION
According to https://docs.conan.io/en/latest/reference/conanfile/attributes.html#license it is strongly recommended to use spdx.org license identifiers.